### PR TITLE
API-4004: Removed calls to Service Locator as it is being retired

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -157,11 +157,6 @@ microservice {
       port = 8500
     }
 
-    service-locator {
-      host = localhost
-      port = 9602
-    }
-
     individuals-matching-api {
       host = localhost
       port = 9653


### PR DESCRIPTION
Microservices no longer need to call Service Locator to register their deployments - this is now handled as part of the Deploy to... Jenkins jobs. There is a related PR to cover the update to pipeline at hmrc/build-jobs#4101

Service Locator is in the process of being retired entirely, so any calls to it will fail. This PR removes the redundant call.

Further detail: https://confluence.tools.tax.service.gov.uk/x/bGNjCQ