### PR TITLE
DLS-1472 revert scalatestplus-play to 3.1.2

### DIFF
--- a/app/uk/gov/hmrc/individualsemploymentsapi/connector/DesConnector.scala
+++ b/app/uk/gov/hmrc/individualsemploymentsapi/connector/DesConnector.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.individualsemploymentsapi.connector
 
 import javax.inject.{Inject, Singleton}
 import org.joda.time.Interval
+import play.api.Logger
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.http.logging.Authorization

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ def test(scope: String = "test,it") = Seq(
   "org.scalatest"          %% "scalatest"                % "3.0.8"             % scope,
   "org.pegdown"            % "pegdown"                   % "1.6.0"             % scope,
   "com.typesafe.play"      %% "play-test"                % PlayVersion.current % scope,
-  "org.scalatestplus.play" %% "scalatestplus-play"       % "3.1.3"             % scope,
+  "org.scalatestplus.play" %% "scalatestplus-play"       % "3.1.2"             % scope,
   "org.scalaj"             %% "scalaj-http"              % "2.4.2"             % scope,
   "org.mockito"            % "mockito-all"               % "1.10.19"           % scope,
   "com.github.tomakehurst" % "wiremock-jre8"             % "2.21.0"            % scope


### PR DESCRIPTION
DLS-1472 revert scalatestplus-play to 3.1.2, version 3.1.3 is built against Play 2.6.25 and add a  missing import