### PR TITLE
MDS-448 | Error Handling

### DIFF
--- a/app/uk/gov/hmrc/individualsemploymentsapi/error/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/individualsemploymentsapi/error/ErrorResponses.scala
@@ -29,7 +29,7 @@ object ErrorResponses {
   }
 
   case object ErrorNotFound extends ErrorResponse(NOT_FOUND, "NOT_FOUND", "The resource can not be found")
-  case object ErrorInternalServer
+  case class ErrorInternalServer(errorMessage: String = "Failed to process request")
       extends ErrorResponse(INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "Failed to process request")
   case object ErrorTooManyRequests extends ErrorResponse(TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "Rate limit exceeded")
   case class ErrorUnauthorized(errorMessage: String) extends ErrorResponse(UNAUTHORIZED, "UNAUTHORIZED", errorMessage)

--- a/app/uk/gov/hmrc/individualsemploymentsapi/error/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/individualsemploymentsapi/error/ErrorResponses.scala
@@ -30,7 +30,7 @@ object ErrorResponses {
 
   case object ErrorNotFound extends ErrorResponse(NOT_FOUND, "NOT_FOUND", "The resource can not be found")
   case class ErrorInternalServer(errorMessage: String = "Failed to process request")
-      extends ErrorResponse(INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "Failed to process request")
+      extends ErrorResponse(INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", message=errorMessage)
   case object ErrorTooManyRequests extends ErrorResponse(TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "Rate limit exceeded")
   case class ErrorUnauthorized(errorMessage: String) extends ErrorResponse(UNAUTHORIZED, "UNAUTHORIZED", errorMessage)
   case class ErrorInvalidRequest(errorMessage: String)

--- a/test/component/uk/gov/hmrc/individualsemploymentsapi/stubs/AuthStub.scala
+++ b/test/component/uk/gov/hmrc/individualsemploymentsapi/stubs/AuthStub.scala
@@ -87,4 +87,14 @@ object AuthStub extends MockHost(22000) {
           .withStatus(Status.UNAUTHORIZED)
           .withHeader(HeaderNames.WWW_AUTHENTICATE, """MDTP detail="Bearer token is missing or not authorized"""")))
 
+  def willNotAuthorizePrivilegedAuthTokenNoScopes(authBearerToken: String): StubMapping =
+    mock.register(
+      post(urlEqualTo("/auth/authorise"))
+        .withHeader(AUTHORIZATION, equalTo(authBearerToken))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.UNAUTHORIZED)
+            .withHeader(
+              HeaderNames.WWW_AUTHENTICATE,
+              """MDTP detail="InsufficientEnrolments"""")))
 }

--- a/test/component/uk/gov/hmrc/individualsemploymentsapi/stubs/IfStub.scala
+++ b/test/component/uk/gov/hmrc/individualsemploymentsapi/stubs/IfStub.scala
@@ -18,7 +18,7 @@ package component.uk.gov.hmrc.individualsemploymentsapi.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import component.uk.gov.hmrc.individualsemploymentsapi.controller.MockHost
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
 import uk.gov.hmrc.individualsemploymentsapi.domain.integrationframework.IfEmployments
 
@@ -39,6 +39,15 @@ object IfStub extends MockHost(22004) {
             "employments(employer(address(line1,line2,line3,line4,line5,postcode),districtNumber,name,schemeRef),employment(endDate,startDate))")
         )
         .willReturn(aResponse().withStatus(OK).withBody(Json.toJson(ifEmployments).toString())))
+
+  def saCustomResponse(nino: String, status: Int, fromDate: String, toDate: String, response: JsValue) =
+    mock.register(
+      get(urlPathEqualTo(s"/individuals/employment/nino/$nino"))
+        .withQueryParam("startDate", equalTo(fromDate))
+        .withQueryParam("endDate", equalTo(toDate))
+        .withQueryParam("fields", equalTo("employments(employer(address(line1,line2,line3,line4,line5,postcode),districtNumber,name,schemeRef),employment(endDate,startDate))"))
+        .willReturn(aResponse().withStatus(status).withBody(Json.toJson(response.toString()).toString())))
+
 
   def enforceRateLimit(nino: String, fromDate: String, toDate: String): Unit =
     mock.register(

--- a/test/it/uk/gov/hmrc/individualsemploymentsapi/connector/IfConnectorSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsemploymentsapi/connector/IfConnectorSpec.scala
@@ -28,7 +28,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpClient, Upstream5xxResponse}
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpClient, InternalServerException, Upstream5xxResponse}
 import uk.gov.hmrc.individualsemploymentsapi.audit.v2.AuditHelper
 import uk.gov.hmrc.individualsemploymentsapi.connector.IfConnector
 import uk.gov.hmrc.individualsemploymentsapi.domain.integrationframework.IfEmployments
@@ -103,7 +103,7 @@ class IfConnectorSpec extends SpecBase with BeforeAndAfterEach with Intervals wi
         get(urlPathMatching(s"/individuals/employment/nino/$nino"))
           .willReturn(aResponse().withStatus(500)))
 
-      intercept[Upstream5xxResponse] {
+      intercept[InternalServerException] {
         await(
           underTest.fetchEmployments(nino, interval, None, matchId)(
             hc,
@@ -125,7 +125,7 @@ class IfConnectorSpec extends SpecBase with BeforeAndAfterEach with Intervals wi
         get(urlPathMatching(s"/individuals/employment/nino/$nino"))
           .willReturn(aResponse().withStatus(400)))
 
-      intercept[BadRequestException] {
+      intercept[InternalServerException] {
         await(
           underTest.fetchEmployments(nino, interval, None, matchId)(
             hc,


### PR DESCRIPTION
Updated the error handling so errors are not passed from IF to the user... any 4xxs or 5xxs will get logged and audited, but the user receive an Internal Server Error - "Something went wrong."

Error handling added to cover a lack of valid scopes, instead of returning one of the invalid scopes.

Added a generic, catch-all error ("Something went wrong.")