### PR TITLE
HODS-394: Adding in UUID validation for V2 while not touching V1.

### DIFF
--- a/app/uk/gov/hmrc/individualsemploymentsapi/util/StringQueryStringBinder.scala
+++ b/app/uk/gov/hmrc/individualsemploymentsapi/util/StringQueryStringBinder.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.individualsemploymentsapi.util
+
+import play.api.mvc.QueryStringBindable
+
+class StringQueryStringBinder(implicit stringBinder : QueryStringBindable[String]) extends QueryStringBindable[String] {
+
+  private val handledKeys = Seq("matchId")
+
+  override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, String]] = {
+    if (handledKeys.contains(key)) {
+      Option(params.get(key).flatMap(_.headOption) match {
+        case Some(x) => Right(x)
+        case None => Left(s"$key is required")
+      })
+    } else {
+      stringBinder.bind(key, params)
+    }
+  }
+
+  override def unbind(key: String, value: String): String = s"$key=$value"
+}

--- a/app/uk/gov/hmrc/individualsemploymentsapi/util/UuidValidator.scala
+++ b/app/uk/gov/hmrc/individualsemploymentsapi/util/UuidValidator.scala
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.individualsemploymentsapi
+package uk.gov.hmrc.individualsemploymentsapi.util
 
-import uk.gov.hmrc.individualsemploymentsapi.util.{IntervalQueryStringBinder, MatchUuidQueryStringBinder, StringQueryStringBinder}
+object UuidValidator {
+  val uuidPattern = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$"
 
-package object Binders {
-  implicit val matchUuidQueryStringBinder = new MatchUuidQueryStringBinder
-  implicit val intervalQueryStringBinder = new IntervalQueryStringBinder
-  implicit val stringQueryStringBinder = new StringQueryStringBinder
+  def validate(uuid: String): Boolean = uuid.matches(uuidPattern)
 }

--- a/conf/app_version_2_0.routes
+++ b/conf/app_version_2_0.routes
@@ -1,4 +1,4 @@
 # microservice specific routes
-GET        /                        @uk.gov.hmrc.individualsemploymentsapi.controller.v2.EmploymentsController.root(matchId: java.util.UUID)
-GET        /paye                    @uk.gov.hmrc.individualsemploymentsapi.controller.v2.EmploymentsController.paye(matchId: java.util.UUID, interval: org.joda.time.Interval, payeReference: Option[String])
+GET        /                        @uk.gov.hmrc.individualsemploymentsapi.controller.v2.EmploymentsController.root(matchId: java.lang.String)
+GET        /paye                    @uk.gov.hmrc.individualsemploymentsapi.controller.v2.EmploymentsController.paye(matchId: java.lang.String, interval: org.joda.time.Interval, payeReference: Option[String])
 

--- a/test/unit/uk/gov/hmrc/individualsemploymentsapi/controller/v2/EmploymentsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsemploymentsapi/controller/v2/EmploymentsControllerSpec.scala
@@ -121,7 +121,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
         .thenReturn(Future.failed(new MatchNotFoundException))
 
       val eventualResult =
-        employmentsController.root(randomMatchId)(FakeRequest().withHeaders(validCorrelationHeader))
+        employmentsController.root(randomMatchId.toString)(FakeRequest().withHeaders(validCorrelationHeader))
 
       status(eventualResult) shouldBe NOT_FOUND
       contentAsJson(eventualResult) shouldBe Json.obj(
@@ -141,7 +141,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
         .thenReturn(Future.failed(new MatchNotFoundException))
 
       val eventualResult =
-        employmentsController.root(randomMatchId)(FakeRequest())
+        employmentsController.root(randomMatchId.toString)(FakeRequest())
 
       status(eventualResult) shouldBe BAD_REQUEST
       contentAsJson(eventualResult) shouldBe Json.obj(
@@ -162,7 +162,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
         .thenReturn(Future.failed(new MatchNotFoundException))
 
       val eventualResult =
-        employmentsController.root(randomMatchId)(FakeRequest().withHeaders("CorrelationId" -> "FOO"))
+        employmentsController.root(randomMatchId.toString)(FakeRequest().withHeaders("CorrelationId" -> "FOO"))
 
       status(eventualResult) shouldBe BAD_REQUEST
       contentAsJson(eventualResult) shouldBe Json.obj(
@@ -183,7 +183,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
         .thenReturn(Future.successful(NinoMatch(randomMatchId, Nino("AB123456C"))))
 
       val eventualResult =
-        employmentsController.root(randomMatchId)(FakeRequest().withHeaders(validCorrelationHeader))
+        employmentsController.root(randomMatchId.toString)(FakeRequest().withHeaders(validCorrelationHeader))
 
       status(eventualResult) shouldBe OK
       contentAsJson(eventualResult) shouldBe Json.obj(
@@ -212,7 +212,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
       when(mockAuthConnector.authorise(any(), any())(any(), any()))
         .thenReturn(Future.failed(InsufficientEnrolments()))
 
-      val result = employmentsController.root(randomMatchId)(FakeRequest().withHeaders(validCorrelationHeader))
+      val result = employmentsController.root(randomMatchId.toString)(FakeRequest().withHeaders(validCorrelationHeader))
 
       status(result) shouldBe UNAUTHORIZED
       verifyNoInteractions(mockEmploymentsService)
@@ -228,7 +228,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
       when(mockAuthConnector.authorise(any(), any())(any(), any()))
         .thenReturn(Future.failed(new Exception("Test Exception")))
 
-      val result = employmentsController.root(randomMatchId)(FakeRequest().withHeaders(validCorrelationHeader))
+      val result = employmentsController.root(randomMatchId.toString)(FakeRequest().withHeaders(validCorrelationHeader))
 
       status(result) shouldBe INTERNAL_SERVER_ERROR
       verifyNoInteractions(mockEmploymentsService)
@@ -254,7 +254,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
         .thenReturn(Future.failed(new MatchNotFoundException))
 
       val eventualResult =
-        employmentsController.paye(invalidMatchId, interval, None)(FakeRequest().withHeaders(validCorrelationHeader))
+        employmentsController.paye(invalidMatchId.toString, interval, None)(FakeRequest().withHeaders(validCorrelationHeader))
 
       status(eventualResult) shouldBe NOT_FOUND
 
@@ -277,7 +277,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
         .thenReturn(Future.successful(Seq(Employment.create(ifEmploymentExample).get)))
 
       val res =
-        employmentsController.paye(matchId, interval, None)(FakeRequest().withHeaders(validCorrelationHeader))
+        employmentsController.paye(matchId.toString, interval, None)(FakeRequest().withHeaders(validCorrelationHeader))
 
       status(res) shouldBe OK
 
@@ -322,7 +322,7 @@ class EmploymentsControllerSpec extends SpecBase with AuthHelper with MockitoSug
       when(mockAuthConnector.authorise(any(), any())(any(), any())).thenReturn(Future.failed(InsufficientEnrolments()))
 
       val result =
-        employmentsController.paye(sampleMatchId, interval, None)(FakeRequest().withHeaders(validCorrelationHeader))
+        employmentsController.paye(sampleMatchId.toString, interval, None)(FakeRequest().withHeaders(validCorrelationHeader))
 
       status(result) shouldBe UNAUTHORIZED
       verifyNoInteractions(mockEmploymentsService)

--- a/test/unit/uk/gov/hmrc/individualsemploymentsapi/util/UuidValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsemploymentsapi/util/UuidValidatorSpec.scala
@@ -14,12 +14,23 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.individualsemploymentsapi
+package unit.uk.gov.hmrc.individualsemploymentsapi.util
 
-import uk.gov.hmrc.individualsemploymentsapi.util.{IntervalQueryStringBinder, MatchUuidQueryStringBinder, StringQueryStringBinder}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.individualsemploymentsapi.util.UuidValidator
 
-package object Binders {
-  implicit val matchUuidQueryStringBinder = new MatchUuidQueryStringBinder
-  implicit val intervalQueryStringBinder = new IntervalQueryStringBinder
-  implicit val stringQueryStringBinder = new StringQueryStringBinder
+class UuidValidatorSpec extends AnyWordSpec with Matchers {
+
+  private val invalidUuid = "0-0-0-0-0"
+  private val validUuid = "a1c15e8f-b119-4121-bc08-6baf2af45099"
+
+  "Return true on a a valid UUID" in {
+    UuidValidator.validate(validUuid) shouldBe true
+  }
+
+  "Return false on invalid UUID" in {
+    UuidValidator.validate(invalidUuid) shouldBe false
+  }
+
 }


### PR DESCRIPTION
String binder uses default play to pass through. Added The query string binder to modify messages when options are missing to comply with current spec tests.