### PR TITLE
DLS-12860 | Update SCTS test fixtures to include employerRef

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -213,7 +213,7 @@ api-config {
           fields = ["A", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M"]
         }
         "read:individuals-employments-scts" {
-          fields = [ "A", "D", "E", "F", "G", "H", "I", "L", "N", "O" ]
+          fields = [ "A", "D", "E", "F", "G", "H", "I", "L", "M", "N", "O" ]
         }
     }
 

--- a/test/component/uk/gov/hmrc/individualsemploymentsapi/v2/IfQueriesSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsemploymentsapi/v2/IfQueriesSpec.scala
@@ -89,7 +89,7 @@ class IfQueriesSpec extends BaseSpec {
     }
     Scenario("For read:individuals-employments-scts") {
       val queryString = helper.getQueryStringFor(Seq("read:individuals-employments-scts"), List("paye"))
-      queryString shouldBe "employments(employer(address(line1,line2,line3,line4,line5,postcode),name),employment(endDate),payments(date,paidTaxablePay))"
+      queryString shouldBe "employments(employer(address(line1,line2,line3,line4,line5,postcode),name),employerRef,employment(endDate),payments(date,paidTaxablePay))"
     }
   }
 }


### PR DESCRIPTION
[info]   Scenario: SCTS journey through Auth, Individuals Matching and Individuals Employments
[info]     Given an authorised SCTS user generates a bearer token 
[info]     When they Post a JSON payload of an individual's details to Individuals Matching to retrieve a valid MatchId 
[info]     Then they should receive a valid MatchId in response 
[info]     When they make a GET request to Individuals Matching using that valid MatchId 
[info]     Then they should receive a record of the same individual in response 
[info]     When they make a Get request to Individuals Employments entrypoint 
[info]     Then they should receive the correct HATEOAS links in response 
[info]     When they make a Get request to Individuals Employments PAYE endpoint 
[info]     Then they should receive the correct Employments PAYE data in response 
[info] OrganisationsDetailsVATSpec:
[info] Feature: Organisations Details API VAT Steps
[info] Run completed in 13 seconds, 571 milliseconds.
[info] Total number of tests run: 43
[info] Suites: completed 7, aborted 0
[info] Tests: succeeded 43, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
